### PR TITLE
mathlib update and adding command line instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ much documentation. Currently there is one such tutorial.
 
 Of course you can look at [this file](src/first_proofs.lean) online but
 the recommended way it to [install Lean](https://github.com/leanprover-community/mathlib/blob/master/README.md) and [get this project](https://github.com/leanprover-community/mathlib/blob/master/docs/install/project.md) for local use.
+
+If you have already installed Lean and mathlib in the recommended manner, and have access to a command line, then installing this project should be as simple as
+
+```
+git clone https://github.com/leanprover-community/tutorials.git
+cd tutorials
+leanpkg configure
+update-mathlib
+```

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "3.4.2"
 path = "src"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "27515619bcd834006f2936b292021135496b4efb"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "acd769af1ee9f01b3e30ac51629a15696d8793a3"}


### PR DESCRIPTION
I don't see why we should make the users click back to the instructions page to see how to install the repo once they're sitting on the github page of the repo.

I also updated mathlib (this should be done once a month or so I guess)
