### PR TITLE
Transposition typo in comments

### DIFF
--- a/src/exercises/02_iff_if_and.lean
+++ b/src/exercises/02_iff_if_and.lean
@@ -251,7 +251,7 @@ But this can be rephrased as
 In order to prove P → Q, we use the tactic `intros`, followed by an assumption name.
 This creates an assumption with that name asserting that P holds, and turns the goal into Q.
 
-Let's check we can go from our old version of l`e_add_of_nonneg_left` to the new one.
+Let's check we can go from our old version of `le_add_of_nonneg_left` to the new one.
 
 -/
 example (a b : ℝ): 0 ≤ a → b ≤ a + b :=

--- a/src/exercises/02_iff_if_and.lean
+++ b/src/exercises/02_iff_if_and.lean
@@ -432,7 +432,7 @@ only use the following three lemmas:
 
   dvd_refl (a : ℕ) : a ∣ a 
 
-  dvd_antisym {a b : ℕ} : a ∣ b → b ∣ a → a = b :=
+  dvd_antisymm {a b : ℕ} : a ∣ b → b ∣ a → a = b :=
   
   dvd_gcd_iff {a b c : ℕ} : c ∣ gcd a b ↔ c ∣ a ∧ c ∣ b
 -/

--- a/src/solutions/02_iff_if_and.lean
+++ b/src/solutions/02_iff_if_and.lean
@@ -292,7 +292,7 @@ But this can be rephrased as
 In order to prove P → Q, we use the tactic `intros`, followed by an assumption name.
 This creates an assumption with that name asserting that P holds, and turns the goal into Q.
 
-Let's check we can go from our old version of l`e_add_of_nonneg_left` to the new one.
+Let's check we can go from our old version of `le_add_of_nonneg_left` to the new one.
 
 -/
 example (a b : ℝ): 0 ≤ a → b ≤ a + b :=

--- a/src/solutions/02_iff_if_and.lean
+++ b/src/solutions/02_iff_if_and.lean
@@ -496,7 +496,7 @@ only use the following three lemmas:
 
   dvd_refl (a : ℕ) : a ∣ a 
 
-  dvd_antisym {a b : ℕ} : a ∣ b → b ∣ a → a = b :=
+  dvd_antisymm {a b : ℕ} : a ∣ b → b ∣ a → a = b :=
   
   dvd_gcd_iff {a b c : ℕ} : c ∣ gcd a b ↔ c ∣ a ∧ c ∣ b
 -/


### PR DESCRIPTION
One of the descriptions for an exercise had two characters transposed.  This commit transposes them back.