### PR TITLE
antisymm seems to be the correct name

### DIFF
--- a/src/exercises/02_iff_if_and.lean
+++ b/src/exercises/02_iff_if_and.lean
@@ -432,7 +432,7 @@ only use the following three lemmas:
 
   dvd_refl (a : ℕ) : a ∣ a 
 
-  dvd_antisym {a b : ℕ} : a ∣ b → b ∣ a → a = b :=
+  dvd_antisymm {a b : ℕ} : a ∣ b → b ∣ a → a = b :=
   
   dvd_gcd_iff {a b c : ℕ} : c ∣ gcd a b ↔ c ∣ a ∧ c ∣ b
 -/

--- a/src/solutions/02_iff_if_and.lean
+++ b/src/solutions/02_iff_if_and.lean
@@ -496,7 +496,7 @@ only use the following three lemmas:
 
   dvd_refl (a : ℕ) : a ∣ a 
 
-  dvd_antisym {a b : ℕ} : a ∣ b → b ∣ a → a = b :=
+  dvd_antisymm {a b : ℕ} : a ∣ b → b ∣ a → a = b :=
   
   dvd_gcd_iff {a b c : ℕ} : c ∣ gcd a b ↔ c ∣ a ∧ c ∣ b
 -/


### PR DESCRIPTION
In the comments for exercise 22, it describes `dvd_antisym`, but the theorem appears to be called `dvd_antisymm`.