### PR TITLE
schedule job to bump Lean/mathlib versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,30 @@
+on:
+  schedule:
+   - cron: '0 0 * * 2'
+
+jobs:
+  publish_archive_job:
+    runs-on: ubuntu-latest
+    name: Bump Lean and mathlib versions
+    steps:
+      - uses: actions/checkout@v2
+      - name: install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: install Python dependencies
+        run: python -m pip install --upgrade pip mathlibtools
+      - name: install Lean
+        run: |
+          curl https://raw.githubusercontent.com/Kha/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "::add-path::$HOME/.elan/bin"
+      - name: upgrade project
+        run: leanproject up
+      - name: build project 
+        run: lean src
+      - name: push changes
+        run: |
+          git config --global user.email "leanprover.community@gmail.com"
+          git config --global user.name "leanprover-community-bot"
+          git commit -am "auto update Lean/mathlib versions" || true
+          git push || true

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -5,4 +5,4 @@ lean_version = "leanprover-community/lean:3.15.0"
 path = "src/solutions"
 
 [dependencies]
-mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "ed5f63608ed6be6b7882ee8659a9f34c44313423"}
+mathlib = {git = "https://github.com/leanprover-community/mathlib", rev = "e48c2af4f2f92c2331a912c588610db73085939d"}


### PR DESCRIPTION
This script runs once a week. It calls `leanproject up` and tries to build the project. If it succeeds, it pushes the result of the update to master. If it fails, this is an alarm to us that the tutorial is outdated.