### PR TITLE
Remove reference to le_max_left.

### DIFF
--- a/mk_exercises.py
+++ b/mk_exercises.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
-import regex
+import re
 from pathlib import Path
 
-sorry_regex = regex.compile(r'(.*)-- sorry.*')
+sorry_regex = re.compile(r'(.*)-- sorry.*')
 root = Path(__file__).parent/'src'
 
 if __name__ == '__main__':

--- a/src/exercises/00_first_proofs.lean
+++ b/src/exercises/00_first_proofs.lean
@@ -292,9 +292,9 @@ begin
     -- We need a lemma saying `z ≤ |z|`. Because we don't know the name of this lemma,
     -- let's use `library_search`. Because searching thourgh the library is slow,
     -- Lean will write what it found in the Lean message window when cursor is on
-    -- that line, so that we can replace it by the lemma. We see `le_max_left` which
-    -- says `a ≤ max a b`. Actually there is a more specific lemma `le_abs_self`
-  ... ≤ x + |u N - x| : add_le_add (by linarith) (by library_search)
+    -- that line, so that we can replace it by the lemma. We see `le_max_self`, which
+    -- says `a ≤ |a|`, exactly what we're looking for.
+  ... ≤ x + |u N - x| : add_le_add (by linarith) (le_abs_self (u N - x))
   ... ≤ x + ε         : add_le_add (by linarith) (HN N (by linarith)),
 end
 

--- a/src/exercises/07_first_negations.lean
+++ b/src/exercises/07_first_negations.lean
@@ -89,7 +89,7 @@ begin
   by_contradiction H,
   change l ≠ l' at H, -- Lean does not need this line
   have ineg : |l-l'| > 0,
-    exact abs_pos_of_ne_zero (sub_ne_zero_of_ne H),
+    exact abs_pos.mpr (sub_ne_zero_of_ne H),
   cases hl ( |l-l'|/4 ) (by linarith) with N hN,
   cases hl' ( |l-l'|/4 ) (by linarith) with N' hN',
   let N₀ := max N N', -- this is a new tactic, whose effect should be clear

--- a/src/solutions/00_first_proofs.lean
+++ b/src/solutions/00_first_proofs.lean
@@ -292,9 +292,9 @@ begin
     -- We need a lemma saying `z ≤ |z|`. Because we don't know the name of this lemma,
     -- let's use `library_search`. Because searching thourgh the library is slow,
     -- Lean will write what it found in the Lean message window when cursor is on
-    -- that line, so that we can replace it by the lemma. We see `le_max_left` which
-    -- says `a ≤ max a b`. Actually there is a more specific lemma `le_abs_self`
-  ... ≤ x + |u N - x| : add_le_add (by linarith) (by library_search)
+    -- that line, so that we can replace it by the lemma. We see `le_max_self`, which
+    -- says `a ≤ |a|`, exactly what we're looking for.
+  ... ≤ x + |u N - x| : add_le_add (by linarith) (le_abs_self (u N - x))
   ... ≤ x + ε         : add_le_add (by linarith) (HN N (by linarith)),
 end
 


### PR DESCRIPTION
At least on the version of Lean currently in the leanpkg.toml,
library_search seems to directly suggest le_abs_self.