### PR TITLE
Add my_exercises to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.olean
 /_target
 /leanpkg.path
+my_exercises


### PR DESCRIPTION
The content of `my_exercises` folder shouldn't be pushed. If someone wants to use git to track the progress of the exercises, it might be better to fork the repo and work directly in the `exercises` folder. 